### PR TITLE
Small fixes

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -1,8 +1,8 @@
 MRuby::Gem::Specification.new('mruby-m2x') do |spec|
   spec.version = '0.0.1'
   spec.license = 'MIT'
-  spec.summary = 'Client library for AT&T’s M2X API'
-  spec.description = 'AT&T’s M2X is a cloud-based fully managed data storage service for network connected machine-to-machine (M2M) devices. From trucks and turbines to vending machines and freight containers, M2X enables the devices that power your business to connect and share valuable data.'
+  spec.summary = 'Client library for AT&T\'s M2X API'
+  spec.description = 'AT&T\'s M2X is a cloud-based fully managed data storage service for network connected machine-to-machine (M2M) devices. From trucks and turbines to vending machines and freight containers, M2X enables the devices that power your business to connect and share valuable data.'
   spec.authors = ['Joe McIlvain']
 
   spec.add_dependency('mruby-http')

--- a/mrblib/m2x-client-resource.rb
+++ b/mrblib/m2x-client-resource.rb
@@ -32,7 +32,7 @@ class M2X::Client::Resource
   end
 
   def inspect
-    "#<#{self.class.name}: #{@attributes.inspect}>"
+    "#<#{self.class.to_s}: #{@attributes.inspect}>"
   end
 
   # The API path of the resource, to be implemented by the subclass.


### PR DESCRIPTION
This PR fixes 2 things:

1. When I was testing on a Raspberry Pi 2, building the library directly will signal the following error:

```
pi@raspberrypi ~/mruby $ ./minirake                                                                                                                  
(in /home/pi/mruby)
GIT CHECKOUT master 
Already on 'master'
rake aborted!
/home/pi/mruby/build/mrbgems/m2x-mruby/mrbgem.rake:4: invalid multibyte char (US-ASCII)
/home/pi/mruby/build/mrbgems/m2x-mruby/mrbgem.rake:4: invalid multibyte char (US-ASCII)
/home/pi/mruby/build/mrbgems/m2x-mruby/mrbgem.rake:4: syntax error, unexpected $end, expecting keyword_end
  spec.summary = 'Client library for AT&T’s M2X API'
                                           ^
Rakefile:15:in `load'
```

I know this is probably due to encoding configurations on a Pi, and chances are I might be able to fix this on the Pi end. However, since this library is mostly dealing with embedded systems which might have all kinds of encoding settings. Maybe it's simply better to remove the affect character, since it's not a big deal, correct?

2. Last time I check, mruby does not have `Class#name` method, a little testing shows the same result:

```
> device = m2x.device("<a valid device ID>")                              
/home/pi/mruby/build/mrbgems/m2x-mruby/mrblib/m2x-client-resource.rb:35: undefined method 'name' for #<Class:0xd57b00> (NoMethodError)
```

So I simply use `Class#to_s` to replace `Class#name`.